### PR TITLE
Add episode request feature

### DIFF
--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -298,6 +298,37 @@ class SonarrAPI extends ServarrBase<{
     }
   }
 
+  public async getEpisodes(seriesId: number): Promise<EpisodeResult[]> {
+    try {
+      const response = await this.axios.get<EpisodeResult[]>('/episode', {
+        params: { seriesId },
+      });
+
+      return response.data;
+    } catch (e) {
+      logger.error('Error retrieving episodes from Sonarr', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+        seriesId,
+      });
+      throw new Error('Failed to retrieve episodes');
+    }
+  }
+
+  public async updateEpisodes(
+    episodes: Partial<EpisodeResult>[]
+  ): Promise<void> {
+    try {
+      await this.axios.put('/episode/bulk', episodes);
+    } catch (e) {
+      logger.error('Error updating episodes in Sonarr', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+      });
+      throw new Error('Failed to update episodes');
+    }
+  }
+
   public async searchSeries(seriesId: number): Promise<void> {
     logger.info('Executing series search command.', {
       label: 'Sonarr API',

--- a/server/entity/EpisodeRequest.ts
+++ b/server/entity/EpisodeRequest.ts
@@ -1,0 +1,40 @@
+import { MediaRequestStatus } from '@server/constants/media';
+import { DbAwareColumn } from '@server/utils/DbColumnHelper';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { MediaRequest } from './MediaRequest';
+
+@Entity()
+class EpisodeRequest {
+  @PrimaryGeneratedColumn()
+  public id: number;
+
+  @Column()
+  public seasonNumber: number;
+
+  @Column()
+  public episodeNumber: number;
+
+  @Column({ type: 'int', default: MediaRequestStatus.PENDING })
+  public status: MediaRequestStatus;
+
+  @ManyToOne(() => MediaRequest, (request) => request.episodes, {
+    onDelete: 'CASCADE',
+  })
+  public request: MediaRequest;
+
+  @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  public createdAt: Date;
+
+  @DbAwareColumn({
+    type: 'datetime',
+    default: () => 'CURRENT_TIMESTAMP',
+    onUpdate: 'CURRENT_TIMESTAMP',
+  })
+  public updatedAt: Date;
+
+  constructor(init?: Partial<EpisodeRequest>) {
+    Object.assign(this, init);
+  }
+}
+
+export default EpisodeRequest;

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -26,6 +26,7 @@ import {
   PrimaryGeneratedColumn,
   RelationCount,
 } from 'typeorm';
+import EpisodeRequest from './EpisodeRequest';
 import Media from './Media';
 import SeasonRequest from './SeasonRequest';
 import { User } from './User';
@@ -385,11 +386,17 @@ export class MediaRequest {
               .filter((season) => season.season_number !== 0)
               .map((season) => season.season_number)
           : (requestBody.seasons as number[]);
+      let requestedEpisodes = requestBody.episodes ?? [];
       if (!settings.main.enableSpecialEpisodes) {
         requestedSeasons = requestedSeasons.filter((sn) => sn > 0);
+        requestedEpisodes = requestedEpisodes.filter(
+          (ep) => ep.seasonNumber > 0
+        );
       }
 
       let existingSeasons: number[] = [];
+      let existingEpisodes: { seasonNumber: number; episodeNumber: number }[] =
+        [];
 
       // We need to check existing requests on this title to make sure we don't double up on seasons that were
       // already requested. In the case they were, we just throw out any duplicates but still approve the request.
@@ -406,6 +413,14 @@ export class MediaRequest {
             const combinedSeasons = request.seasons.map(
               (season) => season.seasonNumber
             );
+
+            existingEpisodes = [
+              ...existingEpisodes,
+              ...request.episodes.map((ep) => ({
+                seasonNumber: ep.seasonNumber,
+                episodeNumber: ep.episodeNumber,
+              })),
+            ];
 
             return [...seasons, ...combinedSeasons];
           }, [] as number[]);
@@ -430,12 +445,22 @@ export class MediaRequest {
       const finalSeasons = requestedSeasons.filter(
         (rs) => !existingSeasons.includes(rs)
       );
+      const finalEpisodes = requestedEpisodes.filter(
+        (re) =>
+          !existingEpisodes.some(
+            (ep) =>
+              ep.seasonNumber === re.seasonNumber &&
+              ep.episodeNumber === re.episodeNumber
+          )
+      );
 
-      if (finalSeasons.length === 0) {
-        throw new NoSeasonsAvailableError('No seasons available to request');
+      if (finalSeasons.length === 0 && finalEpisodes.length === 0) {
+        throw new NoSeasonsAvailableError(
+          'No seasons or episodes available to request'
+        );
       } else if (
         quotas.tv.limit &&
-        finalSeasons.length > (quotas.tv.remaining ?? 0)
+        finalSeasons.length + finalEpisodes.length > (quotas.tv.remaining ?? 0)
       ) {
         throw new QuotaRestrictedError('Series Quota exceeded.');
       }
@@ -485,6 +510,27 @@ export class MediaRequest {
           (sn) =>
             new SeasonRequest({
               seasonNumber: sn,
+              status: user.hasPermission(
+                [
+                  requestBody.is4k
+                    ? Permission.AUTO_APPROVE_4K
+                    : Permission.AUTO_APPROVE,
+                  requestBody.is4k
+                    ? Permission.AUTO_APPROVE_4K_TV
+                    : Permission.AUTO_APPROVE_TV,
+                  Permission.MANAGE_REQUESTS,
+                ],
+                { type: 'or' }
+              )
+                ? MediaRequestStatus.APPROVED
+                : MediaRequestStatus.PENDING,
+            })
+        ),
+        episodes: finalEpisodes.map(
+          (ep) =>
+            new EpisodeRequest({
+              seasonNumber: ep.seasonNumber,
+              episodeNumber: ep.episodeNumber,
               status: user.hasPermission(
                 [
                   requestBody.is4k
@@ -556,6 +602,12 @@ export class MediaRequest {
     cascade: true,
   })
   public seasons: SeasonRequest[];
+
+  @OneToMany(() => EpisodeRequest, (episode) => episode.request, {
+    eager: true,
+    cascade: true,
+  })
+  public episodes: EpisodeRequest[];
 
   @Column({ default: false })
   public is4k: boolean;
@@ -707,6 +759,9 @@ export class MediaRequest {
     if (Array.isArray(this.seasons)) {
       this.seasons.sort((a, b) => a.id - b.id);
     }
+    if (Array.isArray(this.episodes)) {
+      this.episodes.sort((a, b) => a.id - b.id);
+    }
   }
 
   static async sendNotification(
@@ -793,6 +848,12 @@ export class MediaRequest {
               name: 'Requested Seasons',
               value: entity.seasons
                 .map((season) => season.seasonNumber)
+                .join(', '),
+            },
+            {
+              name: 'Requested Episodes',
+              value: entity.episodes
+                .map((ep) => `S${ep.seasonNumber}E${ep.episodeNumber}`)
                 .join(', '),
             },
           ],

--- a/server/entity/User.ts
+++ b/server/entity/User.ts
@@ -24,6 +24,7 @@ import {
   PrimaryGeneratedColumn,
   RelationCount,
 } from 'typeorm';
+import EpisodeRequest from './EpisodeRequest';
 import Issue from './Issue';
 import { MediaRequest } from './MediaRequest';
 import SeasonRequest from './SeasonRequest';
@@ -330,8 +331,19 @@ export class User {
                 .leftJoin('season.request', 'parentRequest')
                 .where('parentRequest.id = request.id');
             }, 'seasonCount')
+            .addSelect((subQuery) => {
+              return subQuery
+                .select('COUNT(episode.id)', 'episodeCount')
+                .from(EpisodeRequest, 'episode')
+                .leftJoin('episode.request', 'parentRequest2')
+                .where('parentRequest2.id = request.id');
+            }, 'episodeCount')
             .getMany()
-        ).reduce((sum: number, req: MediaRequest) => sum + req.seasonCount, 0)
+        ).reduce(
+          (sum: number, req: MediaRequest) =>
+            sum + req.seasonCount + (req as any).episodeCount,
+          0
+        )
       : 0;
 
     return {

--- a/server/interfaces/api/requestInterfaces.ts
+++ b/server/interfaces/api/requestInterfaces.ts
@@ -14,6 +14,10 @@ export type MediaRequestBody = {
   mediaId: number;
   tvdbId?: number;
   seasons?: number[] | 'all';
+  episodes?: {
+    seasonNumber: number;
+    episodeNumber: number;
+  }[];
   is4k?: boolean;
   serverId?: number;
   profileId?: number;

--- a/server/migration/postgres/1747000000000-AddEpisodeRequests.ts
+++ b/server/migration/postgres/1747000000000-AddEpisodeRequests.ts
@@ -1,0 +1,21 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEpisodeRequests1747000000000 implements MigrationInterface {
+  name = 'AddEpisodeRequests1747000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "episode_request" ("id" SERIAL NOT NULL, "seasonNumber" integer NOT NULL, "episodeNumber" integer NOT NULL, "status" integer NOT NULL DEFAULT '1', "createdAt" TIMESTAMP NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP NOT NULL DEFAULT now(), "requestId" integer, CONSTRAINT "PK_episode_request_id" PRIMARY KEY ("id"))`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "episode_request" ADD CONSTRAINT "FK_episode_request_request" FOREIGN KEY ("requestId") REFERENCES "media_request"("id") ON DELETE CASCADE ON UPDATE NO ACTION`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "episode_request" DROP CONSTRAINT "FK_episode_request_request"`
+    );
+    await queryRunner.query(`DROP TABLE "episode_request"`);
+  }
+}

--- a/server/migration/sqlite/1747000000000-AddEpisodeRequests.ts
+++ b/server/migration/sqlite/1747000000000-AddEpisodeRequests.ts
@@ -1,0 +1,34 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEpisodeRequests1747000000000 implements MigrationInterface {
+  name = 'AddEpisodeRequests1747000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "episode_request" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "seasonNumber" integer NOT NULL, "episodeNumber" integer NOT NULL, "status" integer NOT NULL DEFAULT (1), "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "requestId" integer)`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "temporary_episode_request" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "seasonNumber" integer NOT NULL, "episodeNumber" integer NOT NULL, "status" integer NOT NULL DEFAULT (1), "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "requestId" integer, CONSTRAINT "FK_episode_request_request" FOREIGN KEY ("requestId") REFERENCES "media_request" ("id") ON DELETE CASCADE ON UPDATE NO ACTION)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "temporary_episode_request"("id", "seasonNumber", "episodeNumber", "status", "createdAt", "updatedAt", "requestId") SELECT "id", "seasonNumber", "episodeNumber", "status", "createdAt", "updatedAt", "requestId" FROM "episode_request"`
+    );
+    await queryRunner.query(`DROP TABLE "episode_request"`);
+    await queryRunner.query(
+      `ALTER TABLE "temporary_episode_request" RENAME TO "episode_request"`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "episode_request" RENAME TO "temporary_episode_request"`
+    );
+    await queryRunner.query(
+      `CREATE TABLE "episode_request" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "seasonNumber" integer NOT NULL, "episodeNumber" integer NOT NULL, "status" integer NOT NULL DEFAULT (1), "createdAt" datetime NOT NULL DEFAULT (datetime('now')), "updatedAt" datetime NOT NULL DEFAULT (datetime('now')), "requestId" integer)`
+    );
+    await queryRunner.query(
+      `INSERT INTO "episode_request"("id", "seasonNumber", "episodeNumber", "status", "createdAt", "updatedAt", "requestId") SELECT "id", "seasonNumber", "episodeNumber", "status", "createdAt", "updatedAt", "requestId" FROM "temporary_episode_request"`
+    );
+    await queryRunner.query(`DROP TABLE "temporary_episode_request"`);
+  }
+}

--- a/server/routes/request.ts
+++ b/server/routes/request.ts
@@ -498,8 +498,14 @@ requestRoutes.put<{ requestId: string }>(
         request.requestedBy = requestUser as User;
 
         const requestedSeasons = req.body.seasons as number[] | undefined;
+        const requestedEpisodes = req.body.episodes as
+          | { seasonNumber: number; episodeNumber: number }[]
+          | undefined;
 
-        if (!requestedSeasons || requestedSeasons.length === 0) {
+        if (
+          (!requestedSeasons || requestedSeasons.length === 0) &&
+          (!requestedEpisodes || requestedEpisodes.length === 0)
+        ) {
           throw new Error(
             'Missing seasons. If you want to cancel a series request, use the DELETE method.'
           );
@@ -528,7 +534,7 @@ requestRoutes.put<{ requestId: string }>(
             return [...seasons, ...combinedSeasons];
           }, [] as number[]);
 
-        const filteredSeasons = requestedSeasons.filter(
+        const filteredSeasons = (requestedSeasons ?? []).filter(
           (rs) => !existingSeasons.includes(rs)
         );
 
@@ -539,12 +545,12 @@ requestRoutes.put<{ requestId: string }>(
           });
         }
 
-        const newSeasons = requestedSeasons.filter(
+        const newSeasons = (requestedSeasons ?? []).filter(
           (sn) => !request.seasons.map((s) => s.seasonNumber).includes(sn)
         );
 
-        request.seasons = request.seasons.filter((rs) =>
-          filteredSeasons.includes(rs.seasonNumber)
+        request.seasons = request.seasons.filter(
+          (rs) => !requestedSeasons || filteredSeasons.includes(rs.seasonNumber)
         );
 
         if (newSeasons.length > 0) {

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -13,6 +13,7 @@ import {
   MediaType,
 } from '@server/constants/media';
 import { getRepository } from '@server/datasource';
+import EpisodeRequest from '@server/entity/EpisodeRequest';
 import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import SeasonRequest from '@server/entity/SeasonRequest';
@@ -626,6 +627,23 @@ export class MediaRequestSubscriber
             media[entity.is4k ? 'serviceId4k' : 'serviceId'] =
               sonarrSettings?.id;
             await mediaRepository.save(media);
+
+            if (entity.episodes.length > 0) {
+              const allEpisodes = await sonarr.getEpisodes(sonarrSeries.id!);
+              const updates = entity.episodes
+                .map((ep) => {
+                  const match = allEpisodes.find(
+                    (e) =>
+                      e.seasonNumber === ep.seasonNumber &&
+                      e.episodeNumber === ep.episodeNumber
+                  );
+                  return match ? { id: match.id, monitored: true } : null;
+                })
+                .filter(Boolean) as { id: number; monitored: boolean }[];
+              if (updates.length > 0) {
+                await sonarr.updateEpisodes(updates);
+              }
+            }
           })
           .catch(async () => {
             const requestRepository = getRepository(MediaRequest);
@@ -738,6 +756,10 @@ export class MediaRequestSubscriber
       entity.seasons.forEach((season) => {
         season.status = MediaRequestStatus.APPROVED;
         seasonRequestRepository.save(season);
+      });
+      entity.episodes.forEach((episode) => {
+        episode.status = MediaRequestStatus.APPROVED;
+        getRepository(EpisodeRequest).save(episode);
       });
     }
   }


### PR DESCRIPTION
## Summary
- allow API request bodies to specify episodes
- store episode requests on the MediaRequest entity
- create EpisodeRequest entity and migrations
- monitor single episodes in Sonarr

## Testing
- `pnpm typecheck`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684dea9538c88324afdd19c7514e9491