### PR TITLE
Add episode request support

### DIFF
--- a/server/api/servarr/sonarr.ts
+++ b/server/api/servarr/sonarr.ts
@@ -318,6 +318,59 @@ class SonarrAPI extends ServarrBase<{
     }
   }
 
+  public async getEpisodesBySeriesId(
+    seriesId: number
+  ): Promise<EpisodeResult[]> {
+    try {
+      const response = await this.axios.get<EpisodeResult[]>('/episode', {
+        params: { seriesId },
+      });
+
+      return response.data;
+    } catch (e) {
+      logger.error('Failed to retrieve episodes from Sonarr', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+        seriesId,
+      });
+      throw new Error('Failed to retrieve episodes');
+    }
+  }
+
+  public async editEpisode(
+    id: number,
+    episode: Partial<EpisodeResult>
+  ): Promise<EpisodeResult> {
+    try {
+      const response = await this.axios.put<EpisodeResult>(`/episode/${id}`, episode);
+      return response.data;
+    } catch (e) {
+      logger.error('Failed to update episode in Sonarr', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+        episodeId: id,
+      });
+      throw new Error('Failed to update episode');
+    }
+  }
+
+  public async searchEpisodes(episodeIds: number[]): Promise<void> {
+    if (!episodeIds.length) return;
+    logger.info('Executing episode search command.', {
+      label: 'Sonarr API',
+      episodeIds,
+    });
+    try {
+      await this.runCommand('EpisodeSearch', { episodeIds });
+    } catch (e) {
+      logger.error('Failed to run Sonarr episode search.', {
+        label: 'Sonarr API',
+        errorMessage: e.message,
+        episodeIds,
+      });
+    }
+  }
+
   private buildSeasonList(
     seasons: number[],
     existingSeasons?: SonarrSeason[]

--- a/server/entity/EpisodeRequest.ts
+++ b/server/entity/EpisodeRequest.ts
@@ -1,0 +1,40 @@
+import { MediaRequestStatus } from '@server/constants/media';
+import { DbAwareColumn } from '@server/utils/DbColumnHelper';
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { MediaRequest } from './MediaRequest';
+
+@Entity()
+class EpisodeRequest {
+  @PrimaryGeneratedColumn()
+  public id: number;
+
+  @Column()
+  public seasonNumber: number;
+
+  @Column()
+  public episodeNumber: number;
+
+  @Column({ type: 'int', default: MediaRequestStatus.PENDING })
+  public status: MediaRequestStatus;
+
+  @ManyToOne(() => MediaRequest, (request) => request.episodes, {
+    onDelete: 'CASCADE',
+  })
+  public request: MediaRequest;
+
+  @DbAwareColumn({ type: 'datetime', default: () => 'CURRENT_TIMESTAMP' })
+  public createdAt: Date;
+
+  @DbAwareColumn({
+    type: 'datetime',
+    default: () => 'CURRENT_TIMESTAMP',
+    onUpdate: 'CURRENT_TIMESTAMP',
+  })
+  public updatedAt: Date;
+
+  constructor(init?: Partial<EpisodeRequest>) {
+    Object.assign(this, init);
+  }
+}
+
+export default EpisodeRequest;

--- a/server/entity/MediaRequest.ts
+++ b/server/entity/MediaRequest.ts
@@ -28,6 +28,7 @@ import {
 } from 'typeorm';
 import Media from './Media';
 import SeasonRequest from './SeasonRequest';
+import EpisodeRequest from './EpisodeRequest';
 import { User } from './User';
 
 export class RequestPermissionError extends Error {}
@@ -501,6 +502,27 @@ export class MediaRequest {
                 : MediaRequestStatus.PENDING,
             })
         ),
+        episodes: (requestBody.episodes ?? []).map(
+          (ep) =>
+            new EpisodeRequest({
+              seasonNumber: ep.seasonNumber,
+              episodeNumber: ep.episodeNumber,
+              status: user.hasPermission(
+                [
+                  requestBody.is4k
+                    ? Permission.AUTO_APPROVE_4K
+                    : Permission.AUTO_APPROVE,
+                  requestBody.is4k
+                    ? Permission.AUTO_APPROVE_4K_TV
+                    : Permission.AUTO_APPROVE_TV,
+                  Permission.MANAGE_REQUESTS,
+                ],
+                { type: 'or' }
+              )
+                ? MediaRequestStatus.APPROVED
+                : MediaRequestStatus.PENDING,
+            })
+        ),
         isAutoRequest: options.isAutoRequest ?? false,
       });
 
@@ -556,6 +578,15 @@ export class MediaRequest {
     cascade: true,
   })
   public seasons: SeasonRequest[];
+
+  @RelationCount((request: MediaRequest) => request.episodes)
+  public episodeCount: number;
+
+  @OneToMany(() => EpisodeRequest, (episode) => episode.request, {
+    eager: true,
+    cascade: true,
+  })
+  public episodes: EpisodeRequest[];
 
   @Column({ default: false })
   public is4k: boolean;

--- a/server/interfaces/api/requestInterfaces.ts
+++ b/server/interfaces/api/requestInterfaces.ts
@@ -14,6 +14,7 @@ export type MediaRequestBody = {
   mediaId: number;
   tvdbId?: number;
   seasons?: number[] | 'all';
+  episodes?: { seasonNumber: number; episodeNumber: number }[];
   is4k?: boolean;
   serverId?: number;
   profileId?: number;

--- a/server/subscriber/MediaRequestSubscriber.ts
+++ b/server/subscriber/MediaRequestSubscriber.ts
@@ -16,6 +16,7 @@ import { getRepository } from '@server/datasource';
 import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import SeasonRequest from '@server/entity/SeasonRequest';
+import EpisodeRequest from '@server/entity/EpisodeRequest';
 import notificationManager, { Notification } from '@server/lib/notifications';
 import { getSettings } from '@server/lib/settings';
 import logger from '@server/logger';
@@ -596,7 +597,12 @@ export class MediaRequestSubscriber
           rootFolderPath: rootFolder,
           title: series.name,
           tvdbid: tvdbId,
-          seasons: entity.seasons.map((season) => season.seasonNumber),
+          seasons: Array.from(
+            new Set([
+              ...entity.seasons.map((season) => season.seasonNumber),
+              ...entity.episodes.map((ep) => ep.seasonNumber),
+            ])
+          ),
           seasonFolder: sonarrSettings.enableSeasonFolders,
           seriesType,
           tags,
@@ -626,6 +632,24 @@ export class MediaRequestSubscriber
             media[entity.is4k ? 'serviceId4k' : 'serviceId'] =
               sonarrSettings?.id;
             await mediaRepository.save(media);
+
+            if (entity.episodes && entity.episodes.length > 0) {
+              const episodes = await sonarr.getEpisodesBySeriesId(sonarrSeries.id);
+              const toUpdate = episodes.filter((ep) =>
+                entity.episodes.some(
+                  (req) =>
+                    req.seasonNumber === ep.seasonNumber &&
+                    req.episodeNumber === ep.episodeNumber
+                )
+              );
+
+              for (const ep of toUpdate) {
+                await sonarr.editEpisode(ep.id, { monitored: true });
+              }
+              if (toUpdate.length && !sonarrSettings.preventSearch) {
+                await sonarr.searchEpisodes(toUpdate.map((e) => e.id));
+              }
+            }
           })
           .catch(async () => {
             const requestRepository = getRepository(MediaRequest);

--- a/server/subscriber/MediaSubscriber.ts
+++ b/server/subscriber/MediaSubscriber.ts
@@ -8,6 +8,7 @@ import Media from '@server/entity/Media';
 import { MediaRequest } from '@server/entity/MediaRequest';
 import Season from '@server/entity/Season';
 import SeasonRequest from '@server/entity/SeasonRequest';
+import EpisodeRequest from '@server/entity/EpisodeRequest';
 import type { EntitySubscriberInterface, UpdateEvent } from 'typeorm';
 import { EventSubscriber } from 'typeorm';
 
@@ -108,7 +109,42 @@ export class MediaSubscriber implements EntitySubscriberInterface<Media> {
           );
 
           const allSeasonsReady = allSeasonResults.every((result) => result);
-          shouldComplete = allSeasonsReady;
+
+          const allEpisodeResults = await Promise.all(
+            (request.episodes ?? []).map(async (reqEpisode) => {
+              const matchingSeason = event.seasons.find(
+                (mediaSeason) =>
+                  mediaSeason.seasonNumber === reqEpisode.seasonNumber
+              );
+
+              if (!matchingSeason) {
+                return false;
+              }
+
+              const currentSeasonStatus =
+                matchingSeason[request.is4k ? 'status4k' : 'status'];
+
+              const shouldUpdate =
+                currentSeasonStatus === MediaStatus.AVAILABLE ||
+                currentSeasonStatus === MediaStatus.DELETED;
+
+              if (shouldUpdate) {
+                const episodeRepo = getRepository(EpisodeRequest);
+                reqEpisode.status = MediaRequestStatus.COMPLETED;
+                await episodeRepo.save(reqEpisode);
+                return true;
+              }
+
+              return false;
+            })
+          );
+
+          const allEpisodesReady =
+            allEpisodeResults.length > 0
+              ? allEpisodeResults.every((result) => result)
+              : true;
+
+          shouldComplete = allSeasonsReady && allEpisodesReady;
         }
 
         if (shouldComplete) {


### PR DESCRIPTION
## Summary
- allow specifying episode requests in API
- track EpisodeRequest entities
- pass episode info to Sonarr and monitor episodes

## Testing
- `npx tsc -p server/tsconfig.json --noEmit` *(fails: Cannot find type definitions)*
- `pnpm install` *(fails: unsupported pnpm version)*

------
https://chatgpt.com/codex/tasks/task_e_684648236dfc8324bc59d8076c8be1e5